### PR TITLE
Enable pjax on forms which use method=get.

### DIFF
--- a/lib/assets/javascripts/pjax/enable_pjax.js.coffee
+++ b/lib/assets/javascripts/pjax/enable_pjax.js.coffee
@@ -1,1 +1,8 @@
-$ -> $('a:not([data-remote]):not([data-behavior])').pjax('[data-pjax-container]')
+$ ->
+  $('a:not([data-remote]):not([data-behavior])').pjax('[data-pjax-container]')
+  
+  $('form[method=get]:not([data-remote])').live 'submit', (event) ->
+    event.preventDefault()
+    $.pjax
+      container: '[data-pjax-container]'
+      url: this.action + '?' + $(this).serialize()


### PR DESCRIPTION
I've been using pjax to good effect on forms which use `method=get` — such as search forms. So here's a patch that adds pjax support to forms matching `$('form[method=get]:not([data-remote])')`.

A quick demo: http://pjax-rails-forms.heroku.com/
