### PR TITLE
Fixes Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The PJAX container has to be marked with data-pjax-container attribute, so for e
         <%= content_tag :h3, 'My site' %>
         <%= link_to 'About me', about_me_path %>
         <!-- The following link will not be pjax'd -->
-        <%= link_to 'Google', 'http://google.com', :data-skip-pjax => true %>
+        <%= link_to 'Google', 'http://google.com', 'data-skip-pjax' => true %>
       </div>
     </body>
 


### PR DESCRIPTION
data tags can't have symbols, ruby will read the hyphen as a minus and through undefined method errors on the next element's name.

Grrr, I screwed up in typing the commit!
