### PR TITLE
Elements with no href or an anchor href should be ignored. 

### DIFF
--- a/lib/assets/javascripts/pjax/jquery_pjax.js
+++ b/lib/assets/javascripts/pjax/jquery_pjax.js
@@ -32,6 +32,11 @@ $.fn.pjax = function( container, options ) {
     // links in a new tab as normal.
     if ( event.which > 1 || event.metaKey )
       return true
+    
+    // Elements with no href or an anchor href should be ignored.
+    var href = $(event.target).attr('href')
+    if ( !href || href.indexOf('#') == 0 )
+      return true
 
     var defaults = {
       url: this.href,


### PR DESCRIPTION
Also sent to jquery-pjax: https://github.com/defunkt/jquery-pjax/pull/53
