### PR TITLE
Change document.title using X-PJAX-Title response header

### DIFF
--- a/lib/assets/javascripts/pjax/jquery_pjax.js
+++ b/lib/assets/javascripts/pjax/jquery_pjax.js
@@ -91,7 +91,7 @@ $.pjax = function( options ) {
     complete: function(){
       $(document).trigger('end.pjax')
     },
-    success: function(data){
+    success: function(data, status, xhr){
       // If we got no data or an entire web page, go directly
       // to the page and let normal error handling happen.
       if ( !$.trim(data) || /<html/i.test(data) )
@@ -100,10 +100,13 @@ $.pjax = function( options ) {
       // Make it happen.
       $container.html(data)
 
-      // If there's a <title> tag in the response, use it as
-      // the page's title.
+      // If there's a <title> tag or X-PJAX-Title header in the
+      // response, use it as the page's title.
       var oldTitle = document.title,
-          title = $.trim( $container.find('title').remove().text() )
+          title = $.trim(
+            $container.find('title').remove().text()
+            || xhr.getResponseHeader("X-PJAX-Title")
+          )
       if ( title ) document.title = title
 
       var state = {


### PR DESCRIPTION
Setting `document.title` using `<title>` tags within views feels a bit hacky.  I've been playing around with setting `document.title` using `response.headers["X-PJAX-Title"]` and it's a lot more flexible.
