### PR TITLE
Wrap pjax setup so spork can trap it

### DIFF
--- a/lib/pjax.rb
+++ b/lib/pjax.rb
@@ -14,6 +14,10 @@ module Pjax
   class Error < StandardError; end
   class Unsupported < Error; end
 
+  def self.setup
+    ApplicationController.send :include, self
+  end
+
   protected
     def pjax_request?
       env['HTTP_X_PJAX'].present?

--- a/lib/pjax_rails.rb
+++ b/lib/pjax_rails.rb
@@ -3,7 +3,7 @@ require 'pjax'
 module PjaxRails
   class Engine < ::Rails::Engine
     initializer "pjax_rails.add_controller" do
-      config.to_prepare { ApplicationController.send :include, Pjax }
+      config.to_prepare { Pjax.setup }
     end
   end
 end


### PR DESCRIPTION
Wraps the inclusion into `ApplicationController` in `Pjax.setup` in the railtie. Pjax_rails otherwise loads `ApplicationController` and anything it references before Spork can fork.

https://github.com/sporkrb/spork/wiki/Spork.trap_method-Jujitsu
