### PR TITLE
Avoid referencing ApplicationController

### DIFF
--- a/lib/pjax_rails.rb
+++ b/lib/pjax_rails.rb
@@ -3,7 +3,9 @@ require 'pjax'
 module PjaxRails
   class Engine < ::Rails::Engine
     initializer "pjax_rails.add_controller" do
-      config.to_prepare { ApplicationController.send :include, Pjax }
+      ActiveSupport.on_load :action_controller do
+        ActionController::Base.send :include, Pjax
+      end
     end
   end
 end


### PR DESCRIPTION
Referencing Application classes can affect the load order of application code and cause subtle bugs between environments.

This replaces the reference to `ApplicationController` with `ActionController::Base`, and makes the initializer consistent with most of the other official rails plugins.
