### PR TITLE
Fix for an empty hash

### DIFF
--- a/vendor/assets/javascripts/jquery.pjax.js
+++ b/vendor/assets/javascripts/jquery.pjax.js
@@ -74,7 +74,10 @@ function handleClick(event, container, options) {
     return
 
   // Ignore anchors on the same page
-  if (link.hash && link.href.replace(link.hash, '') ===
+  var effectiveHash = link.hash, idx = link.href.indexOf('#')
+  if (!effectiveHash && idx > -1)
+    effectiveHash = link.href.substring(idx)
+  if (effectiveHash && link.href.replace(effectiveHash, '') ===
        location.href.replace(location.hash, ''))
     return
 


### PR DESCRIPTION
This wasn't behaving right for certain links on my app. Specifically under these circumstances:
- the current page has a non-empty hash, say `"#15/42.3956/-83.0854"`
- the clicked pjax-enabled link has `href="#"`

You'd expect this to be covered by the "ignore anchors on the same page" clause, BUT with only a `#` on your link, the value of `link.hash` is actually an empty string and we pass right by the desired `return`! Anyway, perhaps I've missed something but it works better for me now, and here I am forking and submitting this idea for your consideration.
