### PR TITLE
replace leading ampersand instead of trailing

### DIFF
--- a/lib/pjax.rb
+++ b/lib/pjax.rb
@@ -49,7 +49,7 @@ module Pjax
 
     def strip_pjax_param
       params.delete(:_pjax)
-      request.env['QUERY_STRING'] = request.env['QUERY_STRING'].sub(/_pjax=[^&]+&?/, '')
+      request.env['QUERY_STRING'] = request.env['QUERY_STRING'].sub(/(?:\?|&)_pjax=[^&]+/, '')
 
       request.env.delete('rack.request.query_string')
       request.env.delete('rack.request.query_hash')

--- a/lib/pjax.rb
+++ b/lib/pjax.rb
@@ -49,7 +49,7 @@ module Pjax
 
     def strip_pjax_param
       params.delete(:_pjax)
-      request.env['QUERY_STRING'] = request.env['QUERY_STRING'].sub(/(^_pjax=[^&]+&?|&_pjax=[^&]+)/, '')
+      request.env['QUERY_STRING'] = request.env['QUERY_STRING'].sub(/^_pjax=[^&]+&?|&_pjax=[^&]+/, '')
 
       request.env.delete('rack.request.query_string')
       request.env.delete('rack.request.query_hash')

--- a/lib/pjax.rb
+++ b/lib/pjax.rb
@@ -49,7 +49,7 @@ module Pjax
 
     def strip_pjax_param
       params.delete(:_pjax)
-      request.env['QUERY_STRING'] = request.env['QUERY_STRING'].sub(/(?:\?|&)_pjax=[^&]+/, '')
+      request.env['QUERY_STRING'] = request.env['QUERY_STRING'].sub(/(^_pjax=[^&]+&?|&_pjax=[^&]+)/, '')
 
       request.env.delete('rack.request.query_string')
       request.env.delete('rack.request.query_hash')


### PR DESCRIPTION
Otherwise requests with query params are updated with an url with a trailing ampersand.
