### PR TITLE
Fix a.compareDocumentPosition is not a function

### DIFF
--- a/vendor/assets/javascripts/jquery.pjax.js
+++ b/vendor/assets/javascripts/jquery.pjax.js
@@ -293,7 +293,7 @@ function pjax(options) {
     }
 
     // Only blur the focus if the focused element is within the container.
-    var blurFocus = $.contains(context, document.activeElement)
+    var blurFocus = $.contains(context.get(0), document.activeElement)
 
     // Clear out any focused controls before inserting new page contents.
     if (blurFocus) {


### PR DESCRIPTION
Found an issue `Uncaught TypeError: a.compareDocumentPosition is not a function` for this released version (v0.5.0).

Environment:
- jQuery 1.8.0
- Ruby 2.4.1
- Rails 5.2.2.1

_There's a same issue in https://github.com/defunkt/jquery-pjax/issues/675 and also related: https://bugs.jquery.com/ticket/7297_